### PR TITLE
solve graphic glitch issue

### DIFF
--- a/core/encodings.js
+++ b/core/encodings.js
@@ -11,7 +11,8 @@ export var encodings = {
     encodingCopyRect: 1,
     encodingRRE: 2,
     encodingHextile: 5,
-    encodingTight: -260,
+    encodingTight: 7,
+    encodingTightPNG: -260,
 
     pseudoEncodingQualityLevel9: -23,
     pseudoEncodingQualityLevel0: -32,
@@ -19,7 +20,6 @@ export var encodings = {
     pseudoEncodingLastRect: -224,
     pseudoEncodingCursor: -239,
     pseudoEncodingQEMUExtendedKeyEvent: -258,
-    pseudoEncodingTightPNG: -260,
     pseudoEncodingExtendedDesktopSize: -308,
     pseudoEncodingXvp: -309,
     pseudoEncodingFence: -312,
@@ -35,6 +35,7 @@ export function encodingName(num) {
         case encodings.encodingRRE:      return "RRE";
         case encodings.encodingHextile:  return "Hextile";
         case encodings.encodingTight:    return "Tight";
+        case encodings.encodingTightPNG:    return "Tight";
         default:                         return "[unknown encoding " + num + "]";
     }
 }

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -170,6 +170,7 @@ export default function RFB(target, url, options) {
     this._encHandlers[encodings.encodingRRE] = RFB.encodingHandlers.RRE.bind(this);
     this._encHandlers[encodings.encodingHextile] = RFB.encodingHandlers.HEXTILE.bind(this);
     this._encHandlers[encodings.encodingTight] = RFB.encodingHandlers.TIGHT.bind(this);
+    this._encHandlers[encodings.encodingTightPNG] = RFB.encodingHandlers.TIGHT.bind(this);
 
     this._encHandlers[encodings.pseudoEncodingDesktopSize] = RFB.encodingHandlers.DesktopSize.bind(this);
     this._encHandlers[encodings.pseudoEncodingLastRect] = RFB.encodingHandlers.last_rect.bind(this);
@@ -1256,13 +1257,13 @@ RFB.prototype = {
         // Only supported with full depth support
         if (this._fb_depth == 24) {
             encs.push(encodings.encodingTight);
+            encs.push(encodings.encodingTightPNG);
             encs.push(encodings.encodingHextile);
             encs.push(encodings.encodingRRE);
         }
         encs.push(encodings.encodingRaw);
 
         // Psuedo-encoding settings
-        encs.push(encodings.pseudoEncodingTightPNG);
         encs.push(encodings.pseudoEncodingQualityLevel0 + 6);
         encs.push(encodings.pseudoEncodingCompressLevel0 + 2);
 


### PR DESCRIPTION
Recover correct tight encoding value. At the same time, disable TightPNG encoding setting during RFB handshake negociation

Signed-off-by: Leslie Qi Wang <qiwa@pensando.io>